### PR TITLE
Migrate to use v1 API

### DIFF
--- a/fluent-plugin-filter_keys.gemspec
+++ b/fluent-plugin-filter_keys.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
+  spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"

--- a/lib/fluent/plugin/out_filter_keys.rb
+++ b/lib/fluent/plugin/out_filter_keys.rb
@@ -1,13 +1,11 @@
 # coding: utf-8
+require 'fluent/plugin/output'
 
 module Fluent
   class FilterKeysOutput < Output
     include Fluent::HandleTagNameMixin
 
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
+    helpers :event_emitter
 
     Fluent::Plugin.register_output('filter_keys', self)
 
@@ -29,7 +27,7 @@ module Fluent
 
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       es.each { |time, record|
         t = tag.dup
         filter_record(t, time, record)
@@ -39,8 +37,6 @@ module Fluent
           router.emit("#{DISCARD_TAG}.#{t}", time, record) if @add_tag_and_reemit
         end
       }
-
-      chain.next
     end
 
     def filter_record(tag, time, record)

--- a/test/plugin/test_out_filter_keys.rb
+++ b/test/plugin/test_out_filter_keys.rb
@@ -8,9 +8,9 @@ class FilterKeysOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
-  def create_driver(conf, tag = 'test')
-    Fluent::Test::OutputTestDriver.new(
-      Fluent::FilterKeysOutput, tag
+  def create_driver(conf)
+    Fluent::Test::Driver::Output.new(
+      Fluent::FilterKeysOutput
     ).configure(conf)
   end
 
@@ -53,8 +53,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'bar' => "100",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 1,                  emits.count
     assert_equal 'filter_keys.test', emits[0][0]
@@ -73,8 +73,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'bar' => "100",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 1,                  emits.count
     assert_equal 'filter_keys.test', emits[0][0]
@@ -93,8 +93,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'at'  => "all",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 0,  emits.count
     assert_equal [], emits
@@ -110,8 +110,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'foo' => "50",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 0,  emits.count
     assert_equal [], emits
@@ -128,8 +128,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'bar' => "100",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 0,  emits.count
     assert_equal [], emits
@@ -146,8 +146,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'bar' => "100",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 1,                  emits.count
     assert_equal 'filter_keys.test', emits[0][0]
@@ -166,10 +166,10 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'bar' => "100",
     }
 
-    d.run do
-      3.times { d.emit(record) }
+    d.run(default_tag: 'test') do
+      3.times { d.feed(record) }
     end
-    emits = d.emits
+    emits = d.events
 
     assert_equal 3, emits.count
 
@@ -191,8 +191,8 @@ class FilterKeysOutputTest < Test::Unit::TestCase
       'foo' => "50",
     }
 
-    d.run { d.emit(record) }
-    emits = d.emits
+    d.run(default_tag: 'test') { d.feed(record) }
+    emits = d.events
 
     assert_equal 1,                  emits.count
     assert_equal 'discarded.filter_keys.test', emits[0][0]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,16 +4,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
-
-unless ENV.has_key?('VERBOSE')
-  nulllogger = Object.new
-  nulllogger.instance_eval {|obj|
-    def method_missing(method, *args)
-      # pass
-    end
-  }
-  $log = nulllogger
-end
+require 'fluent/test/driver/output'
 
 class Test::Unit::TestCase
 end


### PR DESCRIPTION
The brand new Fluentd v1 API can handles multi workers with worker processes, replace common implementation pattern with plugin helpers.